### PR TITLE
Fix install phase of CMakeLists.txt

### DIFF
--- a/indigo/CMakeLists.txt
+++ b/indigo/CMakeLists.txt
@@ -1,11 +1,19 @@
+project(openrtm_aist_python)
+cmake_minimum_required(VERSION 2.8)
+
 if(EXISTS "/etc/debian_version")
   set(SETUPTOOLS_ARG_EXTRA "--install-layout=deb")
 else()
   set(SETUPTOOLS_ARG_EXTRA "")
 endif()
+
 add_custom_target(compile_openrtm_aist_python ALL
   COMMAND python setup.py build
-  COMMAND python setup.py install --prefix=$ENV{PWD}/debian/$ENV{PACKAGE}/${CMAKE_INSTALL_PREFIX} ${SETUPTOOLS_ARG_EXTRA}
   WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
 
+add_custom_target(install_openrtm_aist_python
+  COMMAND python setup.py install --prefix=${CMAKE_INSTALL_PREFIX} ${SETUPTOOLS_ARG_EXTRA} --skip-build
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+
+install(CODE "execute_process(COMMAND \"${CMAKE_COMMAND}\" --build \"${CMAKE_BINARY_DIR}\" --target install_openrtm_aist_python)")
 install(FILES package.xml DESTINATION share/openrtm_aist_python/)


### PR DESCRIPTION
`DESTDIR` is not set at CMake invokation or at the compile phase. Only the install phase.

The proposed solution in 4f9fbc7be4541ba4de6f4d7e13ecbed5a1c94b8e will ONLY work on the debian buildfarm. This one will work on any system.

Specifically tagging @k-okada
