### PR TITLE
Work around a glitch in setuptools

### DIFF
--- a/indigo/CMakeLists.txt
+++ b/indigo/CMakeLists.txt
@@ -12,7 +12,7 @@ add_custom_target(compile_openrtm_aist_python ALL
   WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
 
 add_custom_target(install_openrtm_aist_python
-  COMMAND python setup.py install --prefix=${CMAKE_INSTALL_PREFIX} ${SETUPTOOLS_ARG_EXTRA} --skip-build
+  COMMAND python setup.py install --prefix=$(DESTDIR)${CMAKE_INSTALL_PREFIX} ${SETUPTOOLS_ARG_EXTRA} --skip-build
   WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
 
 install(CODE "execute_process(COMMAND \"${CMAKE_COMMAND}\" --build \"${CMAKE_BINARY_DIR}\" --target install_openrtm_aist_python)")


### PR DESCRIPTION
The `--root` option doesn't seem to work right here. Oh well, prefixing our prefix seems to work.

Sorry I missed this. It seems my build server got confused when you pushed 1.1.0-3 while I was testing this fix. I've thoroughly tested this now, and it should work right.

Thanks,

--scott

(again, specifically tagging @k-okada because this is a release repo)
