### PR TITLE
[noetic] revert 2to3 -f next and other minor changes for rtprint

### DIFF
--- a/0001-noetic-support-2to3-w-.-update-package.xml.patch
+++ b/0001-noetic-support-2to3-w-.-update-package.xml.patch
@@ -1,7 +1,7 @@
-From f15b681f6418af6e93cdb1ff94818dd0bf1606d1 Mon Sep 17 00:00:00 2001
+From f3c6681721d4a87e9def3fbb101e8ed60497c8ed Mon Sep 17 00:00:00 2001
 From: Kei Okada <k-okada@jsk.t.u-tokyo.ac.jp>
 Date: Thu, 28 Sep 2023 17:30:05 +0900
-Subject: [PATCH 1/5] noetic support: 2to3 -w ., update package.xml
+Subject: [PATCH 1/6] noetic support: 2to3 -w ., update package.xml
 
 ---
  package.xml | 2 +-

--- a/0002-replace-variable-named-int-to-int_value.patch
+++ b/0002-replace-variable-named-int-to-int_value.patch
@@ -1,7 +1,7 @@
-From 924725cddc21d44cdb397a70ef18515874d84c6f Mon Sep 17 00:00:00 2001
+From f5e5ff243e3fabf63d88c4bc7c576f032e808ce1 Mon Sep 17 00:00:00 2001
 From: Kei Okada <k-okada@jsk.t.u-tokyo.ac.jp>
 Date: Thu, 28 Sep 2023 17:34:27 +0900
-Subject: [PATCH 2/5] replace variable named 'int' to 'int_value'
+Subject: [PATCH 2/6] replace variable named 'int' to 'int_value'
 
 ---
  OpenRTM_aist/utils/rtc-template/uuid.py | 56 ++++++++++++-------------

--- a/0003-noetic-support-2to3-w.patch
+++ b/0003-noetic-support-2to3-w.patch
@@ -1,7 +1,7 @@
-From a00739299f07f59a681ec85ff5a21057c085d68a Mon Sep 17 00:00:00 2001
+From e6bd51996d242c48fdf55f11bd984acdadfd8234 Mon Sep 17 00:00:00 2001
 From: Kei Okada <k-okada@jsk.t.u-tokyo.ac.jp>
 Date: Thu, 28 Sep 2023 17:44:01 +0900
-Subject: [PATCH 3/5] noetic support: 2to3 -w .
+Subject: [PATCH 3/6] noetic support: 2to3 -w .
 
 ---
  OpenRTM_aist/ConfigAdmin.py                   |  24 +-

--- a/0004-string-does-not-support-join.patch
+++ b/0004-string-does-not-support-join.patch
@@ -1,7 +1,7 @@
-From d16e9b12efc3cde254a401be7f4d408f59841751 Mon Sep 17 00:00:00 2001
+From 642db83c3a5988c08432cfd873a78374e50fd4a0 Mon Sep 17 00:00:00 2001
 From: Kei Okada <k-okada@jsk.t.u-tokyo.ac.jp>
 Date: Fri, 29 Sep 2023 16:54:22 +0900
-Subject: [PATCH 4/5] 'string' does not support 'join'
+Subject: [PATCH 4/6] 'string' does not support 'join'
 
 ---
  setup.py | 2 +-

--- a/0005-remove-IntType-ListType.patch
+++ b/0005-remove-IntType-ListType.patch
@@ -1,7 +1,7 @@
-From 3290ed1574ccf49a782abc74a3960d6d463daee0 Mon Sep 17 00:00:00 2001
+From 142d8f2be41cc0a08fd037c07452e34fe33448e4 Mon Sep 17 00:00:00 2001
 From: Kei Okada <k-okada@jsk.t.u-tokyo.ac.jp>
 Date: Fri, 29 Sep 2023 17:07:29 +0900
-Subject: [PATCH 5/5] remove IntType, ListType
+Subject: [PATCH 5/6] remove IntType, ListType
 
 ---
  OpenRTM_aist/Manager.py | 6 +++---

--- a/0006-revert-2to3-f-next-and-other-minor-changes-for-rtpri.patch
+++ b/0006-revert-2to3-f-next-and-other-minor-changes-for-rtpri.patch
@@ -1,0 +1,128 @@
+From 27c01923f443cd5eea82642f17cca4aea9f05a0e Mon Sep 17 00:00:00 2001
+From: kirohy <yoshioka@jsk.imi.i.u-tokyo.ac.jp>
+Date: Thu, 31 Oct 2024 17:39:44 +0900
+Subject: [PATCH 6/6] revert 2to3 -f next and other minor changes for rtprint
+
+---
+ OpenRTM_aist/NumberingPolicy.py        |  2 +-
+ OpenRTM_aist/SdoServiceAdmin.py        |  2 +-
+ OpenRTM_aist/StateMachine.py           | 12 ++++++------
+ OpenRTM_aist/test/test_StateMachine.py |  4 ++--
+ OpenRTM_aist/uuid.py                   |  2 +-
+ 5 files changed, 11 insertions(+), 11 deletions(-)
+
+diff --git a/OpenRTM_aist/NumberingPolicy.py b/OpenRTM_aist/NumberingPolicy.py
+index 384640c..d713326 100644
+--- a/OpenRTM_aist/NumberingPolicy.py
++++ b/OpenRTM_aist/NumberingPolicy.py
+@@ -46,7 +46,7 @@ class NumberingPolicy:
+   # @else
+   #
+   # @endif
+-  class ObjectNotFound:
++  class ObjectNotFound(BaseException):
+     pass
+ 
+ 
+diff --git a/OpenRTM_aist/SdoServiceAdmin.py b/OpenRTM_aist/SdoServiceAdmin.py
+index 3a686e0..1e01451 100644
+--- a/OpenRTM_aist/SdoServiceAdmin.py
++++ b/OpenRTM_aist/SdoServiceAdmin.py
+@@ -216,7 +216,7 @@ class SdoServiceAdmin:
+   # Virtual destractor.
+   # @endif
+   def __del__(self):
+-    len_ = len(self._proiders)
++    len_ = len(self._providers)
+     for i in range(len_):
+       idx = (len_ - 1) - i
+       self._providers[idx].finalize()
+diff --git a/OpenRTM_aist/StateMachine.py b/OpenRTM_aist/StateMachine.py
+index 4b1f65a..18cea97 100644
+--- a/OpenRTM_aist/StateMachine.py
++++ b/OpenRTM_aist/StateMachine.py
+@@ -357,7 +357,7 @@ class StateMachine:
+     self._states = StateHolder()
+     self._states.curr = states.curr
+     self._states.prev = states.prev
+-    self._states.next = states.__next__
++    self._states.next = states.next
+ 
+ 
+   ##
+@@ -457,7 +457,7 @@ class StateMachine:
+     self.sync(states)
+ 
+     # If no state transition required, execute set of do-actions
+-    if states.curr == states.__next__:
++    if states.curr == states.next:
+       # pre-do
+       if self._predo[states.curr]:
+         self._predo[states.curr](states)
+@@ -480,8 +480,8 @@ class StateMachine:
+       self.sync(states)
+ 
+       # If state transition still required, move to the next state
+-      if states.curr != states.__next__:
+-        states.curr = states.__next__
++      if states.curr != states.next:
++        states.curr = states.next
+         if self._entry[states.curr]:
+           self._entry[states.curr](states)
+         self.update_curr(states.curr)
+@@ -521,7 +521,7 @@ class StateMachine:
+     guard = OpenRTM_aist.ScopedLock(self._mutex)
+     states.prev = self._states.prev
+     states.curr = self._states.curr
+-    states.next = self._states.__next__
++    states.next = self._states.next
+     
+ 
+ 
+@@ -537,7 +537,7 @@ class StateMachine:
+   # @endif
+   def need_trans(self):
+     guard = OpenRTM_aist.ScopedLock(self._mutex)
+-    return (self._states.curr != self._states.__next__)
++    return (self._states.curr != self._states.next)
+ 
+ 
+   ##
+diff --git a/OpenRTM_aist/test/test_StateMachine.py b/OpenRTM_aist/test/test_StateMachine.py
+index 96ee9f2..fede375 100755
+--- a/OpenRTM_aist/test/test_StateMachine.py
++++ b/OpenRTM_aist/test/test_StateMachine.py
+@@ -99,7 +99,7 @@ class TestStateMachine(unittest.TestCase):
+   def test_getStates(self):
+     self.assertEqual(self._sm.getStates().curr, RTC.INACTIVE_STATE)
+     self.assertEqual(self._sm.getStates().prev, RTC.INACTIVE_STATE)
+-    self.assertEqual(self._sm.getStates().__next__, RTC.INACTIVE_STATE)
++    self.assertEqual(self._sm.getStates().next, RTC.INACTIVE_STATE)
+ 
+     st = StateHolder()
+     st.prev = RTC.ERROR_STATE
+@@ -109,7 +109,7 @@ class TestStateMachine(unittest.TestCase):
+ 
+     self.assertEqual(self._sm.getStates().curr, RTC.ERROR_STATE)
+     self.assertEqual(self._sm.getStates().prev, RTC.ERROR_STATE)
+-    self.assertEqual(self._sm.getStates().__next__, RTC.ERROR_STATE)
++    self.assertEqual(self._sm.getStates().next, RTC.ERROR_STATE)
+     
+   def test_getState(self):
+     self.assertEqual(self._sm.getState(), RTC.INACTIVE_STATE)
+diff --git a/OpenRTM_aist/uuid.py b/OpenRTM_aist/uuid.py
+index 3ee2823..6692cfa 100644
+--- a/OpenRTM_aist/uuid.py
++++ b/OpenRTM_aist/uuid.py
+@@ -68,7 +68,7 @@ class UUID(object):
+         if bytes:
+             if len(bytes) != 16:
+                 raise ValueError('bytes is not a 16-char string')
+-            int_value = int(('%02x'*16) % tuple(map(ord, bytes)), 16)
++            int_value = int(('%02x'*16) % tuple(bytes), 16)
+         if fields:
+             if len(fields) != 6:
+                 raise ValueError('fields is not a 6-tuple')
+-- 
+2.25.1
+


### PR DESCRIPTION
revert 2to3 -f next, fix typo, fix exception declaration.
`rtprint` works according to this patch in noetic.