### PR TITLE
Enable to compile on pure Ubuntu Focal

### DIFF
--- a/indigo/CMakeLists.txt
+++ b/indigo/CMakeLists.txt
@@ -7,12 +7,18 @@ else()
   set(SETUPTOOLS_ARG_EXTRA "")
 endif()
 
+find_package(PythonInterp QUIET)
+if(NOT PYTHONINTERP_FOUND)
+  find_package(Python REQUIRED)
+  set(PYTHON_EXECUTABLE ${Python_EXECUTABLE})
+endif()
+
 add_custom_target(compile_openrtm_aist_python ALL
-  COMMAND python setup.py build
+  COMMAND ${PYTHON_EXECUTABLE} setup.py build
   WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
 
 add_custom_target(install_openrtm_aist_python
-  COMMAND python setup.py install --prefix=$(DESTDIR)${CMAKE_INSTALL_PREFIX} ${SETUPTOOLS_ARG_EXTRA} --skip-build
+  COMMAND ${PYTHON_EXECUTABLE} setup.py install --prefix=$(DESTDIR)${CMAKE_INSTALL_PREFIX} ${SETUPTOOLS_ARG_EXTRA} --skip-build
   WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
 
 install(CODE "execute_process(COMMAND \"${CMAKE_COMMAND}\" --build \"${CMAKE_BINARY_DIR}\" --target install_openrtm_aist_python)")


### PR DESCRIPTION
Currently, releasing openrtm_aist_python to Ubuntu Focal fails due to the following error:
```
15:04:59 cd /tmp/binarydeb/ros-noetic-openrtm-aist-python-1.1.0 && python setup.py build
15:04:59 /bin/sh: 1: python: not found
```
https://build.ros.org/job/Nbin_uF64__openrtm_aist_python__ubuntu_focal_amd64__binary/375/console
This is because command `python` does not exist unless `python-is-python3` (or `python-is-python2`) is installed on Ubuntu Focal.

The patch in this PR prevents this error by looking for a suitable Python executable via a CMake feature (`FindPythonInterp` or `FindPython`) instead of calling `python` directly.
I think this patch has a backward compatibility because [openrtm_aist_python requires CMake 2.8](https://github.com/tork-a/openrtm_aist_python-release/blob/fb0c2e559f1d563b4d50412b5d0db5c0670d91cf/indigo/CMakeLists.txt#L2) and [CMake 2.8.0 already has FindPythonInterp](https://cmake.org/cmake/help/v2.8.0/cmake.html#module:FindPythonInterp).
This patch should also have a forward compatibility because [future CMake may drop FindPythonInterp but keep FindPython](https://cmake.org/cmake/help/v4.0/policy/CMP0148.html).